### PR TITLE
Add org nr to footer

### DIFF
--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -1,9 +1,12 @@
 
 <footer>
-    <span class="hide-if-mobile">{{ (.Site.GetPage .Site.Params.director).Params.Phone }} | post@expertanalytics.no | {{ .Site.Params.copyright }}</span>
+    <span class="hide-if-mobile">{{ (.Site.GetPage .Site.Params.director).Params.Phone }} | post@expertanalytics.no | Org nr 924 651 946 | {{ .Site.Params.copyright }}</span>
     <div class="mobile-footer">
       <a href="tel:{{ replace (.Site.GetPage .Site.Params.director).Params.Phone " " ""  }}" class="clear">{{ (.Site.GetPage .Site.Params.director).Params.Phone }}</a>
       <a href="mailto:post@expertanalytics.no" class="clear">post@expertanalytics.no</a>
+      <span>
+        Org nr 924 651 946
+      </span>
       <span>
         {{ .Site.Params.copyright }}
       </span>


### PR DESCRIPTION
As required by law, we now have our organisation number in our footer.